### PR TITLE
Fix CSS class typo

### DIFF
--- a/portfolio-damien/app/portfolio/page.tsx
+++ b/portfolio-damien/app/portfolio/page.tsx
@@ -162,7 +162,7 @@ export default function PortfolioPage() {
                                     alt={event.title}
                                     width={160}
                                     height={120}
-                                    className=" object-cover w-1/4 mi'h-full"
+                                    className="object-cover w-1/4 min-h-full"
                                 />
                             )}
 


### PR DESCRIPTION
## Summary
- fix invalid `min-h-full` typo in portfolio page image

## Testing
- `npm install` *(fails: unable to reach registry)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68762a2237d08328b4614ba521fdbb05