### PR TITLE
Improve responsive design

### DIFF
--- a/portfolio-damien/app/a-propos/page.tsx
+++ b/portfolio-damien/app/a-propos/page.tsx
@@ -56,10 +56,10 @@ export default function AboutPage() {
             alt={data.title}
             width={800}
             height={600}
-            className="w-1/2 h-full object-cover object-[center_top]"
+            className="w-full md:w-1/2 h-full object-cover object-[center_top]"
             priority
           />
-          <div className="md:w-1/2 pl-8 h-full">
+          <div className="w-full md:w-1/2 md:pl-8 h-full mt-6 md:mt-0">
             <h1 className="text-6xl font-bold mb-6">{data.title}</h1>
             <article className='text-left text-lg text-gray-700'>
               <PortableText value={data.description} />

--- a/portfolio-damien/app/page.tsx
+++ b/portfolio-damien/app/page.tsx
@@ -59,7 +59,7 @@ export default function HomePage() {
           speed={800}
           spaceBetween={30}
           slidesPerView={1}
-          className="overflow-hidden flex h-[700px] w-full"
+          className="overflow-hidden flex h-[65vh] sm:h-[700px] w-full"
         >
           {images.map((src, index) => (
             <SwiperSlide key={index} className="flex justify-center items-center h-full">

--- a/portfolio-damien/app/portfolio/gallerie/[slug]/page.tsx
+++ b/portfolio-damien/app/portfolio/gallerie/[slug]/page.tsx
@@ -30,7 +30,7 @@ export default async function GalleryPage({ params }: { params: Promise<{ slug: 
     if (!imagesDoc || !imagesDoc.gallery || imagesDoc.gallery.length === 0) {
         return (
             <main className="h-full flex flex-col justify-center items-center p-6 sm:p-12">
-                <div className="w-1/2 align-center justify-center">
+                <div className="w-full sm:w-1/2 align-center justify-center text-center sm:text-left">
                     <BackButton />
                     <p className="text-start text-lg text-gray-700 mt-6">
                         Il n&apos;y a pas encore de photos pour ce projet.

--- a/portfolio-damien/app/portfolio/page.tsx
+++ b/portfolio-damien/app/portfolio/page.tsx
@@ -80,7 +80,7 @@ export default function PortfolioPage() {
                 transition={{ duration: 0.5, ease: "easeOut" }}
             >
                 {/* Swiper desktop */}
-                <div className="hidden md:flex w-full max-w-5xl h-[1000px] rounded-lg overflow-hidden">
+                <div className="hidden md:flex w-full max-w-5xl h-[70vh] lg:h-[90vh] rounded-lg overflow-hidden">
                     <Swiper
                         modules={[Navigation, Pagination, Autoplay, EffectFade]}
                         onSwiper={(swiper) => (swiperRef.current = swiper)}
@@ -110,7 +110,7 @@ export default function PortfolioPage() {
                                                 alt={event.title}
                                                 width={1600}
                                                 height={900}
-                                                className="object-cover max-h-[500px] w-full"
+                                                className="object-cover max-h-[60vh] w-full"
                                             />
                                         )}
 

--- a/portfolio-damien/app/tarifs/page.tsx
+++ b/portfolio-damien/app/tarifs/page.tsx
@@ -125,11 +125,11 @@ export default function TarifsPage() {
                         {agenda ? (
                             <iframe
                                 src={agenda.url}
-                                width="800"
+                                width="100%"
                                 height="600"
                                 frameBorder="0"
                                 scrolling="no"
-                                className="w-full rounded border"
+                                className="w-full h-[50vh] md:h-[600px] rounded border"
                             ></iframe>
                         ) : (
                             <div className="text-center text-lg text-gray-500">
@@ -141,7 +141,7 @@ export default function TarifsPage() {
 
                 <div className="w-full flex justify-center items-center">
                     <Sheet>
-                        <SheetTrigger className="bg-[#2B2B2B] hover:bg-[#1a1a1a] md:w-1/6 text-white p-4 m-4 cursor-pointer flex justify-center space-x-2">
+                        <SheetTrigger className="bg-[#2B2B2B] hover:bg-[#1a1a1a] w-full md:w-1/6 text-white p-4 m-4 cursor-pointer flex justify-center space-x-2">
                             Prendre Contact
                         </SheetTrigger>
                         <SheetContent>


### PR DESCRIPTION
## Summary
- adjust home page slideshow height for small screens
- tweak portfolio gallery layout sizes
- make about page layout responsive
- improve gallery fallback width
- fix agenda iframe and contact button responsiveness

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68764bbd44408328bf4031eee14d6e32