### PR TITLE
Fix contact email sender and add cookies page

### DIFF
--- a/portfolio-damien/app/api/send-email/route.ts
+++ b/portfolio-damien/app/api/send-email/route.ts
@@ -8,7 +8,7 @@ export async function POST(req: Request) {
 
     try {
         const data = await resend.emails.send({
-            from: 'onboarding@resend.dev',  // ou un email vérifié sur Resend
+            from: body.email,
             to: 'clmwebagency@gmail.com',
             subject: `Nouveau message de ${body.name}`,
             text: `Email: ${body.email}\n\nMessage:\n${body.message}`,

--- a/portfolio-damien/app/traitement-des-cookies/page.tsx
+++ b/portfolio-damien/app/traitement-des-cookies/page.tsx
@@ -1,0 +1,16 @@
+export default function TraitementCookiesPage() {
+    return (
+        <main className="prose mx-auto p-8">
+            <h1>Traitement des cookies</h1>
+            <p>
+                Ce site utilise des cookies strictement nécessaires à son fonctionnement,
+                notamment pour sécuriser le formulaire de contact. Aucune donnée
+                personnelle n'est exploitée à des fins commerciales.
+            </p>
+            <p>
+                En utilisant le formulaire, vous acceptez que ces cookies soient
+                stockés dans votre navigateur le temps de votre navigation.
+            </p>
+        </main>
+    );
+}

--- a/portfolio-damien/app/traitement-des-cookies/page.tsx
+++ b/portfolio-damien/app/traitement-des-cookies/page.tsx
@@ -5,11 +5,11 @@ export default function TraitementCookiesPage() {
             <p>
                 Ce site utilise des cookies strictement nécessaires à son fonctionnement,
                 notamment pour sécuriser le formulaire de contact. Aucune donnée
-                personnelle n'est exploitée à des fins commerciales.
+                personnelle n&apos;est exploitée à des fins commerciales.
             </p>
             <p>
                 En utilisant le formulaire, vous acceptez que ces cookies soient
-                stockés dans votre navigateur le temps de votre navigation.
+                stockeacute;s dans votre navigateur le temps de votre navigation.
             </p>
         </main>
     );

--- a/portfolio-damien/components/navbar.tsx
+++ b/portfolio-damien/components/navbar.tsx
@@ -59,6 +59,7 @@ export default function Navbar() {
                     </div>
                     <p className="mb-4 text-xs text-muted-foreground">DamienVigouroux@gmail.com</p>
                     <a href="/mentions-legales" className="italic font-medium text-sm">Mentions légales</a>
+                    <a href="/traitement-des-cookies" className="italic font-medium text-sm">Traitement des cookies</a>
                 </div>
             </div>
 
@@ -103,6 +104,7 @@ export default function Navbar() {
                     </div>
                     <p className="text-xs text-muted-foreground">DamienVigouroux@gmail.com</p>
                     <a href="/mentions-legales" className="italic text-sm">Mentions légales</a>
+                    <a href="/traitement-des-cookies" className="italic text-sm">Traitement des cookies</a>
                 </div>
             </div>
         </>


### PR DESCRIPTION
## Summary
- send emails from the address that the user typed in the contact form
- link to a new cookies policy page from the navbar
- add the new cookies policy page

## Testing
- `npm install` *(fails: network access blocked)*
- `npm run lint` *(fails: next not installed due to above)*

------
https://chatgpt.com/codex/tasks/task_e_68765ce8ceb08328865b09851b65b157